### PR TITLE
Allow HTTP proxy to be disabled from configuration.

### DIFF
--- a/Proxy.Tests/CharacterisationTests.cs
+++ b/Proxy.Tests/CharacterisationTests.cs
@@ -15,7 +15,7 @@ namespace Proxy.Tests
         [SetUp]
         public void SetUp()
         {
-            _proxy = new PassThroughProxy(ProxyPort);
+            _proxy = new PassThroughProxy(ProxyPort, Configuration.Settings);
             _server = new HttpStubServer(_serverBaseAddress);
             _client = new HttpClient(_handler = new HttpClientHandler
             {

--- a/Proxy.Tests/CharacterisationTests.cs
+++ b/Proxy.Tests/CharacterisationTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Text;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -12,9 +14,13 @@ namespace Proxy.Tests
     [TestFixture]
     internal class CharacterisationTests
     {
-        [SetUp]
-        public void SetUp()
+        public void SetUp(bool rejectHttpProxy = false)
         {
+            Configuration.Settings = new Configuration(
+                new Server(ProxyPort, rejectHttpProxy),
+                new Authentication(false, null, null),
+                new Firewall(false, new Rule[] { }));
+
             _proxy = new PassThroughProxy(ProxyPort, Configuration.Settings);
             _server = new HttpStubServer(_serverBaseAddress);
             _client = new HttpClient(_handler = new HttpClientHandler
@@ -33,22 +39,13 @@ namespace Proxy.Tests
             _proxy?.Dispose();
         }
 
-        [OneTimeSetUp]
-        public void OneTimeSetUp()
-        {
-            Configuration.Settings = new Configuration(
-                new Server(ProxyPort),
-                new Authentication(false, null, null),
-                new Firewall(false, new Rule[] {}));
-        }
-
         private static readonly string MachineName = Environment.MachineName;
 
         private const int ServerPort = 9000;
         private const int ProxyPort = 8889;
 
-        private readonly Uri _serverBaseAddress = new Uri($"http://{MachineName}:{ServerPort}");
-        private readonly Uri _proxyBaseAddress = new Uri($"http://{MachineName}:{ProxyPort}");
+        private Uri _serverBaseAddress = new Uri($"http://{MachineName}:{ServerPort}");
+        private Uri _proxyBaseAddress = new Uri($"http://{MachineName}:{ProxyPort}");
 
         private PassThroughProxy _proxy;
         private HttpStubServer _server;
@@ -57,8 +54,11 @@ namespace Proxy.Tests
         private HttpResponseMessage _response;
 
         [Test]
+        [Parallelizable(ParallelScope.None)]
         public void it_talks_to_server()
         {
+            SetUp();
+
             _server
                 .When(message => message.Method == HttpMethod.Post)
                 .Return(() => new HttpResponseMessage(HttpStatusCode.Created));
@@ -69,6 +69,70 @@ namespace Proxy.Tests
             }).GetAwaiter().GetResult();
 
             Assert.That(_response.StatusCode, Is.EqualTo(HttpStatusCode.Created));
+        }
+
+        [Test]
+        [Parallelizable(ParallelScope.None)]
+        public void it_allows_rejecting_http_proxy()
+        {
+            SetUp(rejectHttpProxy: true);
+            
+            _response = _client.SendAsync(new HttpRequestMessage(HttpMethod.Get, _serverBaseAddress)).GetAwaiter().GetResult();
+
+            Assert.That(_response.StatusCode, Is.EqualTo(HttpStatusCode.MethodNotAllowed));
+        }
+
+        [Test]
+        [Parallelizable(ParallelScope.None)]
+        public void it_accepts_https_tunnel_when_rejecting_http_proxy()
+        {
+            SetUp(rejectHttpProxy: true);
+
+            var content = Guid.NewGuid().ToString();
+            _server
+                .When(message => message.Method == HttpMethod.Get)
+                .Return(() => new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(content),
+                });
+
+            using (var tcpClient = new TcpClient())
+            {
+                tcpClient.Connect(MachineName, ProxyPort);
+                using (var networkStream = tcpClient.GetStream())
+                using (var streamWriter = new StreamWriter(networkStream, Encoding.ASCII))
+                using (var streamReader = new StreamReader(networkStream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 1))
+                {
+                    // Connect
+                    streamWriter.Write($"CONNECT {MachineName}:{ServerPort} HTTP/1.1\r\n");
+                    streamWriter.Write($"Host: {MachineName}:{ServerPort}\r\n");
+                    streamWriter.Write($"\r\n");
+                    streamWriter.Flush();
+
+                    // Wait for the connection to be established.
+                    var connectionEstablished = streamReader.ReadLine();
+                    var emptyLine = streamReader.ReadLine();
+
+                    // Contact the origin server.
+                    streamWriter.Write($"GET / HTTP/1.1\r\n");
+                    streamWriter.Write($"Host: {MachineName}:{ServerPort}\r\n");
+                    streamWriter.Write($"\r\n");
+                    streamWriter.Flush();
+
+                    // Read the response.
+                    var output = new StringBuilder();
+                    int read;
+                    do
+                    {
+                        read = streamReader.Read();
+                        output.Append((char)read);
+                    }
+                    while (read >= 0 && !output.ToString().Contains(content));
+
+                    Assert.True(output.ToString().Contains(content));
+                }
+            }
+
         }
     }
 }

--- a/Proxy.Tests/Proxy.Tests.csproj
+++ b/Proxy.Tests/Proxy.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -73,6 +74,12 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.9.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Proxy.Tests/packages.config
+++ b/Proxy.Tests/packages.config
@@ -5,5 +5,6 @@
   <package id="Microsoft.AspNet.WebApi.SelfHost" version="5.2.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="NUnit" version="3.6.1" targetFramework="net45" />
+  <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net45" />
   <package id="StubServer" version="0.2.2" targetFramework="net45" />
 </packages>

--- a/Proxy/Configurations/Server.cs
+++ b/Proxy/Configurations/Server.cs
@@ -2,11 +2,13 @@ namespace Proxy.Configurations
 {
     public class Server
     {
-        public Server(int port)
+        public Server(int port, bool rejectHttpProxy)
         {
             Port = port;
+            RejectHttpProxy = rejectHttpProxy;
         }
 
         public int Port { get; private set; }
+        public bool RejectHttpProxy { get; private set; }
     }
 }

--- a/Proxy/Handlers/FirewallHandler.cs
+++ b/Proxy/Handlers/FirewallHandler.cs
@@ -15,7 +15,7 @@ namespace Proxy.Handlers
 
         public Task<ExitReason> Run(SessionContext context)
         {
-            if (!Configuration.Settings.Firewall.Enabled)
+            if (!context.Configuration.Firewall.Enabled)
             {
                 return Task.FromResult(ExitReason.NewHostConnectionRequired);
             }
@@ -32,7 +32,7 @@ namespace Proxy.Handlers
 
         private static bool IsAllowed(SessionContext context)
         {
-            return !Configuration.Settings.Firewall.Rules
+            return !context.Configuration.Firewall.Rules
                 .Any(r => r.Pattern.Match(context.Header.Host.Hostname).Success &&
                           r.Action == ActionEnum.Deny);
         }

--- a/Proxy/Handlers/ProxyTypeHandler.cs
+++ b/Proxy/Handlers/ProxyTypeHandler.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.IO;
+using System.Text;
+using System.Threading.Tasks;
 using Proxy.Sessions;
 
 namespace Proxy.Handlers
@@ -11,14 +13,28 @@ namespace Proxy.Handlers
         {
         }
 
-        public Task<ExitReason> Run(SessionContext context)
+        public async Task<ExitReason> Run(SessionContext context)
         {
-            return Task.FromResult(context.Header.Verb == "CONNECT" ? ExitReason.HttpsTunnelRequired : ExitReason.HttpProxyRequired);
+            var exitReason = context.Header.Verb == "CONNECT" ? ExitReason.HttpsTunnelRequired : ExitReason.HttpProxyRequired;
+
+            if (exitReason == ExitReason.HttpProxyRequired && context.Configuration.Server.RejectHttpProxy)
+            {
+                await SendMethodNotAllowed(context.ClientStream);
+                exitReason = ExitReason.TerminationRequired;
+            }
+
+            return exitReason;
         }
 
         public static ProxyTypeHandler Instance()
         {
             return Self;
+        }
+
+        private static async Task SendMethodNotAllowed(Stream stream)
+        {
+            var bytes = Encoding.ASCII.GetBytes("HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\n\r\n");
+            await stream.WriteAsync(bytes, 0, bytes.Length);
         }
     }
 }

--- a/Proxy/PassThroughProxy.cs
+++ b/Proxy/PassThroughProxy.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Sockets;
 using System.Threading;
+using Proxy.Configurations;
 using Proxy.Listeners;
 using Proxy.Sessions;
 
@@ -10,9 +11,18 @@ namespace Proxy
     {
         private ProxyListener _proxyListener;
 
-        public PassThroughProxy(int listenPort)
+        public PassThroughProxy(int listenPort) : this(listenPort, Configuration.Settings)
         {
-            Action<TcpClient, CancellationToken> handleClient = async (client, token) => await new Session().Run(client);
+        }
+
+        public PassThroughProxy(Configuration configuration) : this(configuration.Server.Port, configuration)
+        {
+        }
+
+        public PassThroughProxy(int listenPort, Configuration configuration)
+        {
+            Action<TcpClient, CancellationToken> handleClient =
+                async (client, token) => await new Session().Run(client, configuration);
 
             _proxyListener = new ProxyListener(listenPort, handleClient);
         }

--- a/Proxy/Program.cs
+++ b/Proxy/Program.cs
@@ -8,12 +8,12 @@ namespace Proxy
     {
         private static void Main()
         {
-            MainAsync().Wait();
+            MainAsync().GetAwaiter().GetResult();
         }
 
         private static async Task MainAsync()
         {
-            using (new PassThroughProxy(Configuration.Settings.Server.Port))
+            using (new PassThroughProxy(Configuration.Settings.Server.Port, Configuration.Settings))
             {
                 Console.WriteLine("Proxy is running." +
                                   $" Listening on port {Configuration.Settings.Server.Port}." +

--- a/Proxy/Sessions/Session.cs
+++ b/Proxy/Sessions/Session.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Threading.Tasks;
+using Proxy.Configurations;
 using Proxy.Handlers;
 
 namespace Proxy.Sessions
@@ -20,11 +21,11 @@ namespace Proxy.Sessions
             {ExitReason.NewHostConnected, ProxyTypeHandler.Instance()}
         };
 
-        public async Task Run(TcpClient client)
+        public async Task Run(TcpClient client, Configuration configuration)
         {
             var result = ExitReason.InitializationRequired;
 
-            using (var context = new SessionContext(client))
+            using (var context = new SessionContext(client, configuration))
             {
                 do
                 {

--- a/Proxy/Sessions/SessionContext.cs
+++ b/Proxy/Sessions/SessionContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Sockets;
+using Proxy.Configurations;
 using Proxy.Headers;
 using Proxy.Network;
 
@@ -7,11 +8,14 @@ namespace Proxy.Sessions
 {
     public class SessionContext : IDisposable
     {
-        public SessionContext(TcpClient client)
+        public SessionContext(TcpClient client, Configuration configuration)
         {
+            Configuration = configuration;
             Client = client;
             ClientStream = client.GetStream();
         }
+
+        public Configuration Configuration { get; private set; }
 
         public HttpHeader Header { get; set; }
 


### PR DESCRIPTION
This should be merged after https://github.com/agabani/PassThroughProxy/pull/3.

If you want me to decouple these two, I can. I want a way to reject anything but `CONNECT`.

If you merge #3, the diff of this PR should look like this:
https://github.com/joelverhagen/PassThroughProxy/compare/config-in-context...joelverhagen:allow-proxy-disable