### PR TITLE
Add package metadata

### DIFF
--- a/PassThroughProxy/PassThroughProxy.csproj
+++ b/PassThroughProxy/PassThroughProxy.csproj
@@ -3,6 +3,12 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <RootNamespace>Proxy</RootNamespace>
+    <PackageId>PassThroughProxy</PackageId>
+    <Authors>Ahmed Agabani, Joel Verhagen</Authors>
+    <PackageProjectUrl>https://github.com/agabani/PassThroughProxy</PackageProjectUrl>
+    <PackageTags>https connect proxy tunnel</PackageTags>
+    <PackageVersion>1.0.0</PackageVersion>
+    <Description>A forward proxy server supporting HTTP proxy and HTTPS (CONNECT) tunnels.</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Depends on https://github.com/agabani/PassThroughProxy/pull/5.

If #5 is merged first, the diff should look like this:
https://github.com/joelverhagen/PassThroughProxy/compare/library...joelverhagen:package

It is possible to use .csproj metadata specify .nupkg package metadata. I recommend this route for producing a PassThroughProxy package. I have done so here:
https://www.nuget.org/packages/Knapcode.PassThroughProxy/1.2.0-alpha2

I'd love this to become an official package so please feel free to change this package metadata however you want.